### PR TITLE
feat: JWT HTTP enrollment driver (fast API path)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,9 +18,9 @@ ICLASS_STUDENT_ID=12345
 # ICLASS_BASE_URL when set, otherwise defaults to scaq.
 # ICLASS_PORTAL=scaq
 
-# Enrollment driver: playwright (browser, default) or api (JWT HTTP — faster).
+# Enrollment driver: api (JWT HTTP, default) or playwright (browser fallback).
 # Also selectable in the dashboard Configuration sidebar.
-# ICLASS_ENROLLMENT_DRIVER=playwright
+# ICLASS_ENROLLMENT_DRIVER=api
 
 # Optional: Complete transaction (CAUTION: Set to 1/true to actually pay for classes)
 # ICLASS_COMPLETE_TRANSACTION=0

--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ ICLASS_STUDENT_ID=12345
 # ICLASS_BASE_URL when set, otherwise defaults to scaq.
 # ICLASS_PORTAL=scaq
 
+# Enrollment driver: playwright (browser, default) or api (JWT HTTP — faster).
+# Also selectable in the dashboard Configuration sidebar.
+# ICLASS_ENROLLMENT_DRIVER=playwright
+
 # Optional: Complete transaction (CAUTION: Set to 1/true to actually pay for classes)
 # ICLASS_COMPLETE_TRANSACTION=0
 

--- a/README.md
+++ b/README.md
@@ -74,12 +74,19 @@ The dashboard is a thin wrapper around `iclasspro.py`, which can also be run dir
 python3 iclasspro.py --help
 ```
 
-Class discovery uses the **public Open API** (`--scrape`). Enrollment uses **Playwright** (browser automation). Older scripts that call **`iclasspro_api.py`** forward to `iclasspro.py` with the same arguments.
+Class discovery uses the **public Open API** (`--scrape`). Enrollment defaults to **Playwright** (browser automation). For faster runs, use the **HTTP API** driver (`--driver api` or `ICLASS_ENROLLMENT_DRIVER=api`), which calls the portal JWT API (`/api/jwt/v1`) with the same login the website uses. Older scripts that call **`iclasspro_api.py`** forward to `iclasspro.py` with the same arguments.
+
+Probe JWT login without enrolling:
+
+```bash
+python3 scripts/probe_jwt_login.py
+```
 
 Key flags at a glance:
 
 | Flag | Description |
 |---|---|
+| `--driver` | `playwright` (default) or `api` (JWT HTTP enrollment) |
 | `--schedule` | Path to a schedule JSON file (enrollment) |
 | `--scrape` | Discover classes via Open API and print JSON (no browser login) |
 | `--scrape-days` | Comma-separated days to filter discovery (e.g. `Monday,Wednesday`) |

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ The dashboard is a thin wrapper around `iclasspro.py`, which can also be run dir
 python3 iclasspro.py --help
 ```
 
-Class discovery uses the **public Open API** (`--scrape`). Enrollment defaults to **Playwright** (browser automation). For faster runs, use the **HTTP API** driver (`--driver api` or `ICLASS_ENROLLMENT_DRIVER=api`), which calls the portal JWT API (`/api/jwt/v1`) with the same login the website uses. Older scripts that call **`iclasspro_api.py`** forward to `iclasspro.py` with the same arguments.
+Class discovery uses the **public Open API** (`--scrape`). Enrollment defaults to the **HTTP API** driver (`--driver api` or `ICLASS_ENROLLMENT_DRIVER=api`), which calls the portal JWT API (`/api/jwt/v1`) with the same login the website uses. Use **Playwright** (`--driver playwright`) as a fallback if JWT login fails. Older scripts that call **`iclasspro_api.py`** forward to `iclasspro.py` with the same arguments.
 
 Probe JWT login without enrolling:
 
@@ -86,7 +86,7 @@ Key flags at a glance:
 
 | Flag | Description |
 |---|---|
-| `--driver` | `playwright` (default) or `api` (JWT HTTP enrollment) |
+| `--driver` | `api` (default, JWT HTTP enrollment) or `playwright` (browser fallback) |
 | `--schedule` | Path to a schedule JSON file (enrollment) |
 | `--scrape` | Discover classes via Open API and print JSON (no browser login) |
 | `--scrape-days` | Comma-separated days to filter discovery (e.g. `Monday,Wednesday`) |

--- a/app.py
+++ b/app.py
@@ -2,6 +2,9 @@ import asyncio
 import json
 import os
 import sys
+import warnings
+
+warnings.filterwarnings("ignore", message="urllib3 v2 only supports OpenSSL")
 from typing import Dict, List, Optional
 
 import yaml
@@ -382,6 +385,10 @@ async def websocket_enroll_selected(websocket: WebSocket):
             cmd_args.append("--deep-debug")
 
         child_env = os.environ.copy()
+        child_env.setdefault(
+            "PYTHONWARNINGS",
+            "ignore:urllib3 v2 only supports OpenSSL:Warning",
+        )
         child_env["ICLASS_COMPLETE_TRANSACTION"] = "1" if complete_transaction else "0"
         child_env["ICLASS_DEEP_DEBUG"] = "1" if deep_debug else "0"
         child_env["ICLASS_SEND_EMAIL"] = "1" if send_email else "0"
@@ -512,6 +519,10 @@ async def websocket_endpoint(websocket: WebSocket):
             cmd_args.append("--deep-debug")
 
         child_env = os.environ.copy()
+        child_env.setdefault(
+            "PYTHONWARNINGS",
+            "ignore:urllib3 v2 only supports OpenSSL:Warning",
+        )
         child_env["ICLASS_COMPLETE_TRANSACTION"] = "1" if complete_transaction else "0"
         child_env["ICLASS_DEEP_DEBUG"] = "1" if deep_debug else "0"
         child_env["ICLASS_SEND_EMAIL"] = "1" if send_email else "0"

--- a/app.py
+++ b/app.py
@@ -27,7 +27,7 @@ class SaveConfigRequest(BaseModel):
     complete_transaction: bool
     send_email: bool
     deep_debug: bool
-    enrollment_driver: str = "playwright"
+    enrollment_driver: str = "api"
 
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -45,7 +45,7 @@ def _iclasspro_script() -> str:
 def _normalize_driver(value: Optional[str]) -> str:
     """Return ``api`` or ``playwright``."""
     if not value:
-        return "playwright"
+        return "api"
     v = str(value).strip().lower()
     return "api" if v == "api" else "playwright"
 
@@ -61,7 +61,7 @@ def _enrollment_driver_resolve(websocket_value: Optional[str] = None) -> str:
         "ICLASS_ENROLLMENT_API", "0"
     ).strip().lower() in ("1", "true", "yes"):
         return "api"
-    return "playwright"
+    return "api"
 
 
 def _iclasspro_cmd(enrollment_driver: str) -> list:

--- a/app.py
+++ b/app.py
@@ -27,6 +27,7 @@ class SaveConfigRequest(BaseModel):
     complete_transaction: bool
     send_email: bool
     deep_debug: bool
+    enrollment_driver: str = "playwright"
 
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -39,6 +40,33 @@ load_dotenv(DOTENV_PATH, override=True)
 def _iclasspro_script() -> str:
     """Path to ``iclasspro.py`` next to this app."""
     return os.path.join(BASE_DIR, "iclasspro.py")
+
+
+def _normalize_driver(value: Optional[str]) -> str:
+    """Return ``api`` or ``playwright``."""
+    if not value:
+        return "playwright"
+    v = str(value).strip().lower()
+    return "api" if v == "api" else "playwright"
+
+
+def _enrollment_driver_resolve(websocket_value: Optional[str] = None) -> str:
+    """Enrollment driver: WebSocket override, then ``ICLASS_ENROLLMENT_DRIVER``, then legacy env."""
+    if websocket_value is not None and str(websocket_value).strip() != "":
+        return _normalize_driver(websocket_value)
+    override = _get_config_value("ICLASS_ENROLLMENT_DRIVER", "").strip()
+    if override:
+        return _normalize_driver(override)
+    if _get_config_value("ICLASS_DRIVER", "").strip().lower() == "api" and _get_config_value(
+        "ICLASS_ENROLLMENT_API", "0"
+    ).strip().lower() in ("1", "true", "yes"):
+        return "api"
+    return "playwright"
+
+
+def _iclasspro_cmd(enrollment_driver: str) -> list:
+    """Build argv prefix for ``iclasspro.py`` with driver flag."""
+    return [_iclasspro_script(), "--driver", _normalize_driver(enrollment_driver)]
 
 
 app = FastAPI(title="iClassPro Enrollment Dashboard")
@@ -99,6 +127,7 @@ async def get(request: Request):
         in ("1", "true", "yes"),
         "deep_debug": _get_config_value("ICLASS_DEEP_DEBUG", "0").lower()
         in ("1", "true", "yes"),
+        "enrollment_driver": _enrollment_driver_resolve(),
         "initial_schedule": [],
         "default_schedule_filename": None,
         "locations": _load_locations(),
@@ -144,6 +173,8 @@ async def save_config(request: SaveConfigRequest):
     )
     set_key(DOTENV_PATH, "ICLASS_SEND_EMAIL", "1" if request.send_email else "0")
     set_key(DOTENV_PATH, "ICLASS_DEEP_DEBUG", "1" if request.deep_debug else "0")
+    ed = _normalize_driver(request.enrollment_driver)
+    set_key(DOTENV_PATH, "ICLASS_ENROLLMENT_DRIVER", ed)
     os.environ["ICLASS_EMAIL"] = request.email
     os.environ["ICLASS_PASSWORD"] = request.password
     os.environ["ICLASS_STUDENT_ID"] = request.student_id
@@ -153,6 +184,7 @@ async def save_config(request: SaveConfigRequest):
     )
     os.environ["ICLASS_SEND_EMAIL"] = "1" if request.send_email else "0"
     os.environ["ICLASS_DEEP_DEBUG"] = "1" if request.deep_debug else "0"
+    os.environ["ICLASS_ENROLLMENT_DRIVER"] = ed
     return {"message": "Configuration saved"}
 
 
@@ -306,6 +338,7 @@ async def websocket_enroll_selected(websocket: WebSocket):
         complete_transaction = _as_bool(config.get("complete_transaction", True), True)
         send_email = _as_bool(config.get("send_email", False))
         deep_debug = _as_bool(config.get("deep_debug", False))
+        enrollment_driver = _enrollment_driver_resolve(config.get("enrollment_driver"))
         selected_classes = config.get("selected_classes", [])
 
         if not all([email, password, student_id]):
@@ -327,8 +360,7 @@ async def websocket_enroll_selected(websocket: WebSocket):
 
         await websocket.send_text("Starting enrollment of selected classes...")
 
-        cmd_args = [
-            _iclasspro_script(),
+        cmd_args = _iclasspro_cmd(enrollment_driver) + [
             "--email",
             email,
             "--password",
@@ -353,6 +385,7 @@ async def websocket_enroll_selected(websocket: WebSocket):
         child_env["ICLASS_COMPLETE_TRANSACTION"] = "1" if complete_transaction else "0"
         child_env["ICLASS_DEEP_DEBUG"] = "1" if deep_debug else "0"
         child_env["ICLASS_SEND_EMAIL"] = "1" if send_email else "0"
+        child_env["ICLASS_ENROLLMENT_DRIVER"] = enrollment_driver
 
         process = await asyncio.create_subprocess_exec(
             sys.executable,
@@ -431,6 +464,7 @@ async def websocket_endpoint(websocket: WebSocket):
         complete_transaction = _as_bool(config.get("complete_transaction", True), True)
         send_email = _as_bool(config.get("send_email", False))
         deep_debug = _as_bool(config.get("deep_debug", False))
+        enrollment_driver = _enrollment_driver_resolve(config.get("enrollment_driver"))
         schedule = config.get("schedule", [])
 
         if not all([email, password, student_id]):
@@ -456,8 +490,7 @@ async def websocket_endpoint(websocket: WebSocket):
         await websocket.send_text("Starting iClassPro automation...")
 
         # Build the command arguments
-        cmd_args = [
-            _iclasspro_script(),
+        cmd_args = _iclasspro_cmd(enrollment_driver) + [
             "--email",
             email,
             "--password",
@@ -482,6 +515,7 @@ async def websocket_endpoint(websocket: WebSocket):
         child_env["ICLASS_COMPLETE_TRANSACTION"] = "1" if complete_transaction else "0"
         child_env["ICLASS_DEEP_DEBUG"] = "1" if deep_debug else "0"
         child_env["ICLASS_SEND_EMAIL"] = "1" if send_email else "0"
+        child_env["ICLASS_ENROLLMENT_DRIVER"] = enrollment_driver
 
         process = await asyncio.create_subprocess_exec(
             sys.executable,

--- a/iclasspro.py
+++ b/iclasspro.py
@@ -3,12 +3,8 @@ from __future__ import annotations
 
 import warnings
 
-try:
-    from urllib3.exceptions import NotOpenSSLWarning
-
-    warnings.filterwarnings("ignore", category=NotOpenSSLWarning)
-except ImportError:
-    warnings.filterwarnings("ignore", message="urllib3 v2 only supports OpenSSL")
+# Must run before any urllib3 import (including NotOpenSSLWarning).
+warnings.filterwarnings("ignore", message="urllib3 v2 only supports OpenSSL")
 
 import argparse
 import json

--- a/iclasspro.py
+++ b/iclasspro.py
@@ -2518,8 +2518,10 @@ def open_api_discovery_cli(args: argparse.Namespace) -> int:
 
 
 def _default_cli_driver() -> str:
-    """Enrollment driver from env (``playwright`` default)."""
+    """Enrollment driver from env (``api`` default)."""
     enroll = (os.getenv("ICLASS_ENROLLMENT_DRIVER") or "").strip().lower()
+    if enroll == "playwright":
+        return "playwright"
     if enroll == "api":
         return "api"
     legacy = (os.getenv("ICLASS_DRIVER") or "").strip().lower()
@@ -2529,7 +2531,7 @@ def _default_cli_driver() -> str:
         "yes",
     ):
         return "api"
-    return "playwright"
+    return "api"
 
 
 def main():
@@ -2541,8 +2543,8 @@ def main():
         choices=["playwright", "api"],
         default=_default_cli_driver(),
         help=(
-            "playwright: browser automation (default). "
-            "api: HTTP JWT enrollment (fast; requires working portal login)."
+            "api: HTTP JWT enrollment (default, fast). "
+            "playwright: browser automation (fallback if JWT login fails)."
         ),
     )
     parser.add_argument(

--- a/iclasspro.py
+++ b/iclasspro.py
@@ -1,6 +1,15 @@
 #!/usr/bin/env python3
 from __future__ import annotations
 
+import warnings
+
+try:
+    from urllib3.exceptions import NotOpenSSLWarning
+
+    warnings.filterwarnings("ignore", category=NotOpenSSLWarning)
+except ImportError:
+    warnings.filterwarnings("ignore", message="urllib3 v2 only supports OpenSSL")
+
 import argparse
 import json
 import logging

--- a/iclasspro.py
+++ b/iclasspro.py
@@ -2517,9 +2517,34 @@ def open_api_discovery_cli(args: argparse.Namespace) -> int:
     return 0
 
 
+def _default_cli_driver() -> str:
+    """Enrollment driver from env (``playwright`` default)."""
+    enroll = (os.getenv("ICLASS_ENROLLMENT_DRIVER") or "").strip().lower()
+    if enroll == "api":
+        return "api"
+    legacy = (os.getenv("ICLASS_DRIVER") or "").strip().lower()
+    if legacy == "api" and os.getenv("ICLASS_ENROLLMENT_API", "0").lower() in (
+        "1",
+        "true",
+        "yes",
+    ):
+        return "api"
+    return "playwright"
+
+
 def main():
     """Main execution function."""
     parser = argparse.ArgumentParser(description="iClassPro Enrollment Bot")
+    parser.add_argument(
+        "--driver",
+        type=str,
+        choices=["playwright", "api"],
+        default=_default_cli_driver(),
+        help=(
+            "playwright: browser automation (default). "
+            "api: HTTP JWT enrollment (fast; requires working portal login)."
+        ),
+    )
     parser.add_argument(
         "--portal",
         type=str,
@@ -2630,6 +2655,11 @@ def main():
     args = parser.parse_args()
     if args.scrape:
         sys.exit(open_api_discovery_cli(args))
+
+    if args.driver == "api":
+        from iclasspro_jwt import run_api_enrollment
+
+        sys.exit(run_api_enrollment(args))
 
     # --- Setup Logging ---
     log_file = "iclasspro.log"

--- a/iclasspro.py
+++ b/iclasspro.py
@@ -2723,6 +2723,15 @@ def main():
         driver.webdriver()
         driver.login(email=args.email, password=args.password)
 
+        from iclasspro_jwt import clear_cart_before_enrollment
+
+        clear_cart_before_enrollment(
+            args.email,
+            args.password,
+            portal=args.portal or None,
+            schedule=schedule,
+        )
+
         for i, class_info in enumerate(schedule):
             log_info = {
                 k: v

--- a/iclasspro_jwt.py
+++ b/iclasspro_jwt.py
@@ -158,6 +158,33 @@ class IClassProAPIClient:
     def _post(self, path: str, payload: dict, params: Optional[dict] = None) -> Any:
         return self._request("POST", path, json_body=payload, params=params)
 
+    def _delete(self, path: str, params: Optional[dict] = None) -> Any:
+        return self._request("DELETE", path, params=params)
+
+    def clear_cart(self, location_id: int = 1) -> None:
+        """Empty the portal shopping cart (``DELETE /clear-cart``)."""
+        self.select_organization(location_id)
+        try:
+            before = self._get("count-cart")
+        except Exception:
+            before = "?"
+        result = self._delete("/clear-cart")
+        try:
+            after = self._get("count-cart")
+        except Exception:
+            after = "?"
+        message = ""
+        if isinstance(result, dict):
+            message = str(result.get("message") or "")
+        elif isinstance(result, str):
+            message = result
+        logger.info(
+            "Cart cleared (count %s → %s). %s",
+            before,
+            after,
+            message or "",
+        )
+
     def resolve_location_id(
         self, location_name: str, *, class_detail: Optional[dict] = None
     ) -> int:
@@ -588,6 +615,37 @@ def enroll_from_schedule(
     return summary, checkout_result
 
 
+def clear_cart_before_enrollment(
+    email: str,
+    password: str,
+    portal: Optional[str] = None,
+    schedule: Optional[list] = None,
+) -> None:
+    """Log in via JWT and empty the cart before Playwright or API enrollment."""
+    portal_slug = (portal or "").strip() or _default_portal_slug()
+    client = IClassProAPIClient(email, password, portal_slug)
+    try:
+        client.login()
+    except Exception as exc:
+        logger.warning("Skipping cart clear (login failed): %s", exc)
+        return
+
+    location_id = 1
+    if schedule:
+        first = schedule[0] if isinstance(schedule[0], dict) else {}
+        loc = (first.get("Location") or first.get("location") or "").strip()
+        if loc:
+            try:
+                location_id = client.resolve_location_id(loc)
+            except Exception as exc:
+                logger.debug("Location resolve for cart clear failed: %s", exc)
+
+    try:
+        client.clear_cart(location_id)
+    except Exception as exc:
+        logger.warning("Could not clear cart before enrollment (continuing): %s", exc)
+
+
 def _match_open_catalog_row(
     client: IClassProAPIClient,
     location: str,
@@ -649,6 +707,10 @@ def run_api_enrollment(args: argparse.Namespace) -> int:
             "ICLASS_ENROLLMENT_DRIVER=playwright in .env or the dashboard driver dropdown."
         )
         return 1
+
+    clear_cart_before_enrollment(
+        args.email, args.password, portal_slug, schedule=schedule
+    )
 
     effective_complete = args.complete_transaction and not args.dry_run
     if args.dry_run and args.complete_transaction:

--- a/iclasspro_jwt.py
+++ b/iclasspro_jwt.py
@@ -8,6 +8,15 @@ Reverse-engineered from the customer portal SPA (``/api/jwt/v1`` on
 
 from __future__ import annotations
 
+import warnings
+
+try:
+    from urllib3.exceptions import NotOpenSSLWarning
+
+    warnings.filterwarnings("ignore", category=NotOpenSSLWarning)
+except ImportError:
+    warnings.filterwarnings("ignore", message="urllib3 v2 only supports OpenSSL")
+
 import argparse
 import json
 import logging

--- a/iclasspro_jwt.py
+++ b/iclasspro_jwt.py
@@ -1,0 +1,625 @@
+#!/usr/bin/env python3
+"""JWT REST client for iClassPro portal enrollment (cart + checkout).
+
+Reverse-engineered from the customer portal SPA (``/api/jwt/v1`` on
+``app.iclasspro.com``). Discovery still uses the public Open API in
+``iclasspro.py``; this module handles authenticated enrollment only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import sys
+from typing import Any, Optional
+from urllib.parse import urlparse
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+JWT_API_BASE = "https://app.iclasspro.com/api/jwt/v1"
+LOGIN_URL = f"{JWT_API_BASE}/login"
+OPEN_API_BASE = "https://app.iclasspro.com/api/open/v1"
+
+_CLASS_ID_RE = re.compile(r"/class-details/(\d+)")
+
+
+class EnrollmentSkipped(Exception):
+    """Intentional skip (already enrolled / in cart)."""
+
+    def __init__(self, reason: str):
+        super().__init__(reason)
+        self.reason = reason
+
+
+class IClassProAPIError(RuntimeError):
+    """API returned hasErrors or an unexpected HTTP status."""
+
+
+def _api_message(body: Any, fallback: str = "API error") -> str:
+    if isinstance(body, dict):
+        return str(body.get("message") or body.get("error") or fallback)
+    return fallback
+
+
+def _unwrap_data(body: Any) -> Any:
+    """Return ``data`` from a portal envelope; raise on ``hasErrors``."""
+    if not isinstance(body, dict):
+        return body
+    if body.get("hasErrors"):
+        errors = body.get("errors")
+        data_err = (body.get("data") or {}).get("errors")
+        detail = errors or data_err or body
+        raise IClassProAPIError(f"{_api_message(body)}: {detail}")
+    if "data" in body:
+        return body["data"]
+    return body
+
+
+class IClassProAPIClient:
+    """Customer-portal JWT API (token query param, SPA-shaped payloads)."""
+
+    def __init__(self, email: str, password: str, portal: str) -> None:
+        self.email = email
+        self.password = password
+        self.portal = portal.strip().strip("/")
+        self.token: Optional[str] = None
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Accept": "application/json, text/plain, */*",
+                "Content-Type": "application/json",
+                "Origin": "https://portal.iclasspro.com",
+                "Referer": f"https://portal.iclasspro.com/{self.portal}/",
+                "User-Agent": (
+                    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+                    "AppleWebKit/537.36 (KHTML, like Gecko) "
+                    "Chrome/120.0.0.0 Safari/537.36"
+                ),
+            }
+        )
+        self._location_ids: dict[str, int] = {}
+
+    def login(self) -> str:
+        """Authenticate; store ``access_token`` for subsequent calls."""
+        logger.info("Logging in as %s (account=%s)...", self.email, self.portal)
+        payload = {
+            "email": self.email,
+            "password": self.password,
+            "type": "customer",
+            "account": self.portal,
+            "multipleLoginSupport": True,
+        }
+        resp = self.session.post(LOGIN_URL, json=payload, timeout=45)
+        if resp.status_code >= 400:
+            try:
+                body = resp.json()
+                msg = _api_message(body, resp.text)
+            except ValueError:
+                msg = resp.text or resp.reason
+            hint = ""
+            if resp.status_code == 500 and "account" in payload:
+                hint = (
+                    " (If credentials work in the browser, prefer "
+                    "ICLASS_ENROLLMENT_DRIVER=playwright or hybrid.)"
+                )
+            raise RuntimeError(f"Login failed ({resp.status_code}): {msg}{hint}") from None
+
+        body = resp.json()
+        if isinstance(body, dict) and body.get("hasErrors"):
+            raise RuntimeError(f"Login failed: {_api_message(body)}")
+
+        data = _unwrap_data(body)
+        token = None
+        if isinstance(data, dict):
+            token = data.get("access_token") or data.get("token")
+        if not token and isinstance(body, dict):
+            token = body.get("access_token") or body.get("token")
+        if not token:
+            raise RuntimeError(f"Login response contained no access_token: {body}")
+        self.token = str(token)
+        logger.info("Login successful.")
+        return self.token
+
+    def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        json_body: Optional[dict] = None,
+        params: Optional[dict] = None,
+    ) -> Any:
+        if not self.token:
+            self.login()
+        p = dict(params or {})
+        p["token"] = self.token
+        path = path if path.startswith("/") else f"/{path}"
+        url = f"{JWT_API_BASE}{path}"
+        resp = self.session.request(
+            method, url, json=json_body, params=p, timeout=45
+        )
+        if resp.status_code >= 400:
+            try:
+                err_body = resp.json()
+                msg = _api_message(err_body, resp.text)
+            except ValueError:
+                msg = resp.text or resp.reason
+            raise IClassProAPIError(f"HTTP {resp.status_code}: {msg}")
+        body = resp.json()
+        return _unwrap_data(body)
+
+    def _get(self, path: str, params: Optional[dict] = None) -> Any:
+        return self._request("GET", path, params=params)
+
+    def _post(self, path: str, payload: dict, params: Optional[dict] = None) -> Any:
+        return self._request("POST", path, json_body=payload, params=params)
+
+    def resolve_location_id(self, location_name: str) -> int:
+        """Map a schedule location label to Open API location id."""
+        key = location_name.strip().lower()
+        if key in self._location_ids:
+            return self._location_ids[key]
+        data = self._fetch_open(f"{self.portal}/locations")
+        rows = data if isinstance(data, list) else (data or {}).get("data") or []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            name = str(row.get("name") or "").strip()
+            lid = row.get("id")
+            if name and lid is not None:
+                self._location_ids[name.lower()] = int(lid)
+        needle = key
+        for name, lid in self._location_ids.items():
+            if needle == name or needle in name or name in needle:
+                return lid
+        raise ValueError(f"Could not resolve location id for {location_name!r}")
+
+    def _fetch_open(self, path: str, params: Optional[dict] = None) -> Any:
+        slug_path = path.strip("/")
+        url = f"{OPEN_API_BASE}/{slug_path}"
+        resp = self.session.get(url, params=params or {}, timeout=45)
+        resp.raise_for_status()
+        return resp.json()
+
+    def fetch_open_class_row(
+        self,
+        class_id: int,
+        *,
+        day_index: Optional[int] = None,
+        location_filter: Optional[str] = None,
+    ) -> Optional[dict]:
+        """Find one class row from the public catalog by id (and optional filters)."""
+        page = 1
+        while page <= 50:
+            params: dict[str, Any] = {"limit": 80, "page": page}
+            if day_index is not None:
+                params["days"] = str(day_index)
+            if location_filter:
+                params["q"] = location_filter
+            body = self._fetch_open(f"{self.portal}/classes", params)
+            rows = body.get("data") or []
+            for row in rows:
+                if int(row.get("id") or 0) == int(class_id):
+                    return row
+            total = int(body.get("totalRecords") or 0)
+            if not rows or page * 80 >= total:
+                break
+            page += 1
+        return None
+
+    def get_class_detail(self, class_id: int, student_id: int) -> dict:
+        data = self._get(
+            f"classes/{class_id}", params={"selectedStudentIds": student_id}
+        )
+        return data if isinstance(data, dict) else {}
+
+    def get_payment_methods(self) -> list:
+        data = self._get("family-payment-method")
+        if isinstance(data, list):
+            return data
+        if isinstance(data, dict):
+            return data.get("paymentMethods") or data.get("methods") or []
+        return []
+
+    def fetch_new_cart_item(
+        self,
+        class_id: int,
+        session_id: int,
+        student_id: int,
+        *,
+        start_date: Optional[str] = None,
+    ) -> dict:
+        path = f"/new-cart-item/{class_id}/{session_id}"
+        params: dict[str, Any] = {"selectedStudentIds": student_id}
+        if start_date:
+            params["startDate"] = start_date
+        data = self._get(path, params=params)
+        return data if isinstance(data, dict) else {}
+
+    def _build_cart_item_payload(
+        self,
+        new_cart_data: dict,
+        class_id: int,
+        session_id: int,
+        student_id: int,
+        *,
+        start_date: Optional[str] = None,
+    ) -> dict:
+        """Build a ``newCartItems[]`` element from ``new-cart-item`` API data."""
+        item = dict(new_cart_data.get("cartItem") or new_cart_data.get("newCartItem") or {})
+        if not item:
+            details = new_cart_data.get("cartItemDetails") or {}
+            if isinstance(details, dict) and details:
+                item = {"cartItemDetails": details}
+        item.setdefault("objectId", class_id)
+        item.setdefault("sessionId", session_id)
+        item.setdefault("selectedStudentIds", [student_id])
+        if start_date:
+            item.setdefault("startDate", start_date)
+        elif new_cart_data.get("startDate"):
+            item.setdefault("startDate", new_cart_data.get("startDate"))
+        return item
+
+    def add_session_to_cart(
+        self,
+        class_id: int,
+        session_id: int,
+        student_id: int,
+        location_id: int,
+        *,
+        start_date: Optional[str] = None,
+    ) -> None:
+        """Validate and add one session — mirrors portal Enroll → Add to Cart."""
+        logger.info(
+            "Adding to cart: class=%s session=%s student=%s location=%s",
+            class_id,
+            session_id,
+            student_id,
+            location_id,
+        )
+        draft = self.fetch_new_cart_item(
+            class_id, session_id, student_id, start_date=start_date
+        )
+        cart_item = self._build_cart_item_payload(
+            draft, class_id, session_id, student_id, start_date=start_date
+        )
+        new_cart_items = [cart_item]
+        body = {"newCartItems": new_cart_items, "locationId": location_id}
+        self._post("/validate-cart-item", body)
+        self._post("/add-cart-item", body)
+        logger.info("Cart item added (class=%s, session=%s).", class_id, session_id)
+
+    def apply_promo_code(self, code: str) -> None:
+        logger.info("Applying promo code: %s", code)
+        self._post("/add-promo-code", {"promoCode": code, "promoCodes": [code]})
+
+    def validate_cart(self, location_id: int) -> dict:
+        data = self._get(f"/validate-cart/{location_id}")
+        return data if isinstance(data, dict) else {}
+
+    def checkout(
+        self,
+        location_id: int,
+        *,
+        payment_method_id: Optional[int] = None,
+        complete_transaction: bool = True,
+    ) -> dict:
+        """Submit cart for payment at a location (``process-cart``)."""
+        if not complete_transaction:
+            logger.info("Dry-run: skipping process-cart (complete_transaction=False).")
+            return {
+                "dry_run": True,
+                "message": "Transaction not submitted (dry-run mode).",
+            }
+
+        cart_state = self.validate_cart(location_id)
+        transaction_id = cart_state.get("transactionId") or cart_state.get(
+            "TransactionId"
+        )
+        payment_total = cart_state.get("paymentTotal") or cart_state.get("total") or 0
+        payment_amount = cart_state.get("paymentAmount") or payment_total
+
+        if payment_method_id is None:
+            methods = self.get_payment_methods()
+            if methods:
+                payment_method_id = methods[0].get("id")
+
+        payload: dict[str, Any] = {
+            "useCardOnFile": True,
+            "paymentAmount": payment_amount,
+            "paymentTotal": payment_total,
+            "useAccountCredit": False,
+        }
+        if transaction_id is not None:
+            payload["transactionId"] = transaction_id
+            payload["TransactionId"] = transaction_id
+        if payment_method_id is not None:
+            payload["paymentMethodId"] = payment_method_id
+
+        logger.info(
+            "Submitting process-cart (location=%s, transactionId=%s)...",
+            location_id,
+            transaction_id,
+        )
+        result = self._post(f"/process-cart/{location_id}", payload)
+        return result if isinstance(result, dict) else {"result": result}
+
+
+def _parse_class_id_from_url(url: str) -> Optional[int]:
+    m = _CLASS_ID_RE.search(url or "")
+    return int(m.group(1)) if m else None
+
+
+def _session_id_from_open_row(row: dict) -> Optional[int]:
+    sessions = row.get("sessions") or []
+    if not sessions:
+        return None
+    first = sessions[0]
+    if isinstance(first, dict):
+        sid = first.get("id") or first.get("sessionId")
+    else:
+        sid = first
+    try:
+        return int(sid) if sid is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def enroll_from_schedule(
+    client: IClassProAPIClient,
+    schedule: list,
+    student_id: int,
+    *,
+    promo_code: Optional[str] = None,
+    complete_transaction: bool = False,
+) -> tuple[list, Optional[dict]]:
+    """Add each schedule row to the cart, then checkout once for its location."""
+    from iclasspro import DAY_TO_QUERY_INDEX
+
+    summary: list = []
+    added_by_location: dict[int, int] = {}
+
+    for entry in schedule:
+        location = (entry.get("Location") or entry.get("location") or "").strip()
+        time_str = (entry.get("Time") or entry.get("time") or "").strip()
+        day = (entry.get("Day") or entry.get("day") or "").strip()
+        label = f"{location} {day} {time_str}".strip()
+        result: dict[str, Any] = {
+            "label": label,
+            "location": location,
+            "time": time_str,
+            "day": day,
+        }
+
+        try:
+            location_id = client.resolve_location_id(location)
+            class_url = str(entry.get("url") or "").strip()
+            class_id = _parse_class_id_from_url(class_url)
+
+            day_idx = DAY_TO_QUERY_INDEX.get(day.lower())
+            open_row = None
+            if class_id is not None:
+                open_row = client.fetch_open_class_row(
+                    class_id, day_index=day_idx, location_filter=location
+                )
+            elif day_idx is not None:
+                open_row = _match_open_catalog_row(client, location, time_str, day_idx)
+                if open_row:
+                    class_id = int(open_row["id"])
+
+            if class_id is None:
+                raise ValueError(f"No class found for {label}")
+
+            session_id = None
+            start_date = None
+            if open_row:
+                session_id = _session_id_from_open_row(open_row)
+                start_date = open_row.get("startDate") or None
+                if not start_date:
+                    dates = open_row.get("availableDates") or []
+                    if dates:
+                        start_date = dates[0]
+
+            if session_id is None:
+                detail = client.get_class_detail(class_id, student_id)
+                sessions = detail.get("sessions") or []
+                if not sessions:
+                    raise ValueError(f"No sessions found for class {class_id}")
+                sess = sessions[0]
+                session_id = int(sess.get("id") or sess.get("sessionId"))
+                start_date = start_date or sess.get("startDate")
+
+            client.add_session_to_cart(
+                class_id,
+                session_id,
+                student_id,
+                location_id,
+                start_date=start_date,
+            )
+            added_by_location[location_id] = added_by_location.get(location_id, 0) + 1
+            result["status"] = "Success"
+            result["details"] = "Added to cart"
+
+        except EnrollmentSkipped as exc:
+            result["status"] = "Skipped"
+            result["details"] = exc.reason
+        except Exception as exc:
+            logger.error("Failed for %s: %s", label, exc)
+            result["status"] = "Failed"
+            result["details"] = str(exc)
+
+        summary.append(result)
+
+    checkout_result: Optional[dict] = None
+    if added_by_location and complete_transaction:
+        if promo_code:
+            try:
+                client.apply_promo_code(promo_code)
+            except Exception as exc:
+                logger.warning("Promo code failed (continuing): %s", exc)
+
+        # One checkout per location that received items (usually one).
+        checkout_results = []
+        for loc_id in added_by_location:
+            checkout_results.append(client.checkout(loc_id, complete_transaction=True))
+        checkout_result = (
+            checkout_results[0] if len(checkout_results) == 1 else checkout_results
+        )
+
+    elif added_by_location and not complete_transaction:
+        loc_id = next(iter(added_by_location))
+        checkout_result = client.checkout(loc_id, complete_transaction=False)
+
+    return summary, checkout_result
+
+
+def _match_open_catalog_row(
+    client: IClassProAPIClient,
+    location: str,
+    time_str: str,
+    day_index: int,
+) -> Optional[dict]:
+    """Match schedule row against Open API catalog (same shape as discovery)."""
+    from iclasspro import _normalize_open_time, _open_api_fetch_classes_all
+
+    rows = _open_api_fetch_classes_all(client.portal)
+    loc_l = location.lower()
+    want_time = _normalize_open_time(time_str)
+    for row in rows:
+        sched_list = row.get("schedule") or []
+        if not sched_list:
+            continue
+        sched = sched_list[0]
+        day_num = int(sched.get("dayNumber") or 0)
+        if day_num != day_index:
+            continue
+        row_time = _normalize_open_time(str(sched.get("startTime") or ""))
+        name = (row.get("name") or "").lower()
+        if want_time != row_time:
+            continue
+        if loc_l not in name:
+            continue
+        return row
+    return None
+
+
+def run_api_enrollment(args: argparse.Namespace) -> int:
+    """JWT enrollment entry (called from ``iclasspro.py --driver api``)."""
+    if not args.email or not args.password:
+        logger.error("--email and --password required for API enrollment.")
+        return 1
+    if not args.schedule:
+        logger.error("--schedule required for enrollment.")
+        return 1
+
+    portal_slug = args.portal or _default_portal_slug()
+    try:
+        with open(args.schedule, encoding="utf-8") as fh:
+            schedule = json.load(fh)
+    except OSError as exc:
+        logger.error("Could not read schedule %r: %s", args.schedule, exc)
+        return 1
+
+    if not schedule:
+        logger.error("Schedule is empty.")
+        return 1
+
+    client = IClassProAPIClient(args.email, args.password, portal_slug)
+    try:
+        client.login()
+    except Exception as exc:
+        logger.error("Login failed: %s", exc)
+        logger.error(
+            "Use Playwright for enrollment if JWT login fails: "
+            "ICLASS_ENROLLMENT_DRIVER=playwright in .env or the dashboard driver dropdown."
+        )
+        return 1
+
+    effective_complete = args.complete_transaction and not args.dry_run
+    if args.dry_run and args.complete_transaction:
+        logger.info("Dry-run flag enabled; overriding complete-transaction.")
+
+    logger.info(
+        "API enrollment: %d class(es), complete_transaction=%s",
+        len(schedule),
+        effective_complete,
+    )
+
+    summary, checkout_result = enroll_from_schedule(
+        client,
+        schedule,
+        int(args.student_id),
+        promo_code=args.promo_code or None,
+        complete_transaction=effective_complete,
+    )
+
+    print("\n=== Enrollment Run Report ===")
+    for row in summary:
+        icon = {"Success": "\u2714", "Skipped": "\u27f3", "Failed": "\u2718"}.get(
+            row.get("status"), "?"
+        )
+        print(f"  {icon} [{row.get('status', '?'):8s}] {row.get('label', '')}")
+        if row.get("details") and row.get("status") != "Success":
+            print(f"             {row['details']}")
+
+    if checkout_result is not None:
+        print("\n=== Checkout ===")
+        print(json.dumps(checkout_result, indent=2, default=str)[:2000])
+
+    failed = sum(1 for r in summary if r.get("status") == "Failed")
+    print(
+        f"\nSummary: "
+        f"{sum(1 for r in summary if r.get('status') == 'Success')} added, "
+        f"{sum(1 for r in summary if r.get('status') == 'Skipped')} skipped, "
+        f"{failed} failed."
+    )
+    return 0 if failed == 0 else 1
+
+
+def _default_portal_slug() -> str:
+    env_portal = (os.getenv("ICLASS_PORTAL") or "").strip()
+    if env_portal:
+        return env_portal
+    base = (os.getenv("ICLASS_BASE_URL") or "").strip()
+    if base:
+        try:
+            path = urlparse(base).path.strip("/")
+            if path:
+                return path.split("/")[0]
+        except Exception:
+            pass
+    return "scaq"
+
+
+def main() -> int:
+    """CLI probe: ``python -m iclasspro_jwt --email ... --password ...``."""
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(levelname)s] %(message)s",
+        datefmt="%H:%M:%S",
+    )
+    from dotenv import load_dotenv
+
+    load_dotenv(override=True)
+    parser = argparse.ArgumentParser(description="iClassPro JWT API probe")
+    parser.add_argument("--email", default=os.getenv("ICLASS_EMAIL"))
+    parser.add_argument("--password", default=os.getenv("ICLASS_PASSWORD"))
+    parser.add_argument("--portal", default=os.getenv("ICLASS_PORTAL") or _default_portal_slug())
+    parser.add_argument("--student-id", type=int, default=os.getenv("ICLASS_STUDENT_ID"))
+    parser.add_argument("--schedule", default=os.getenv("ICLASS_SCHEDULE"))
+    parser.add_argument("--promo-code", default=os.getenv("ICLASS_PROMO_CODE", ""))
+    parser.add_argument("--complete-transaction", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args()
+    if not args.student_id:
+        logger.error("--student-id required")
+        return 1
+    return run_api_enrollment(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/iclasspro_jwt.py
+++ b/iclasspro_jwt.py
@@ -420,18 +420,31 @@ class IClassProAPIClient:
 
         logger.info("Cart item added (class=%s, session=%s).", class_id, session_id)
 
-    def apply_promo_code(self, code: str) -> None:
-        logger.info("Applying promo code: %s", code)
+    def apply_promo_code(self, code: str, *, location_id: int = 1) -> None:
+        """Apply a cart promo (portal SPA: ``promoCode`` + empty ``promoCodes``)."""
+        raw = code.strip()
+        if not raw:
+            return
+        self.select_organization(location_id)
+        logger.info("Applying promo code...")
         last_error: Optional[Exception] = None
-        for variant in (code, code.lower(), code.upper()):
+        # Portal sends lowercase promoCode and promoCodes: [] (not [code]).
+        for variant in (raw.lower(), raw):
             if not variant:
                 continue
             try:
                 self._post(
                     "/add-promo-code",
-                    {"promoCode": variant, "promoCodes": [variant]},
+                    {"promoCode": variant, "promoCodes": []},
                 )
-                return
+                cart_state = self.validate_cart(location_id)
+                if cart_state.get("promoCodes"):
+                    due = cart_state.get("totalCartDueAmount")
+                    logger.info(
+                        "Promo applied (cart due=%s).", due if due is not None else "?"
+                    )
+                    return
+                raise IClassProAPIError("Promo request succeeded but cart has no promo.")
             except Exception as exc:
                 last_error = exc
         if last_error:
@@ -587,11 +600,8 @@ def enroll_from_schedule(
     checkout_result: Optional[dict] = None
     if added_by_location:
         if promo_code:
-            try:
-                client.apply_promo_code(promo_code)
-                logger.info("Promo code applied.")
-            except Exception as exc:
-                logger.warning("Promo code failed (continuing): %s", exc)
+            loc_id = next(iter(added_by_location))
+            client.apply_promo_code(promo_code, location_id=loc_id)
 
         if complete_transaction:
             checkout_results = []
@@ -610,6 +620,11 @@ def enroll_from_schedule(
                 "message": "Transaction not submitted (dry-run mode).",
                 "cart_total_due": cart_state.get("totalCartDueAmount"),
                 "cart_items": len(cart_state.get("cartItems") or []),
+                "promo_codes": [
+                    p.get("code")
+                    for p in (cart_state.get("promoCodes") or [])
+                    if isinstance(p, dict)
+                ],
             }
 
     return summary, checkout_result

--- a/iclasspro_jwt.py
+++ b/iclasspro_jwt.py
@@ -10,12 +10,7 @@ from __future__ import annotations
 
 import warnings
 
-try:
-    from urllib3.exceptions import NotOpenSSLWarning
-
-    warnings.filterwarnings("ignore", category=NotOpenSSLWarning)
-except ImportError:
-    warnings.filterwarnings("ignore", message="urllib3 v2 only supports OpenSSL")
+warnings.filterwarnings("ignore", message="urllib3 v2 only supports OpenSSL")
 
 import argparse
 import json

--- a/iclasspro_jwt.py
+++ b/iclasspro_jwt.py
@@ -158,25 +158,54 @@ class IClassProAPIClient:
     def _post(self, path: str, payload: dict, params: Optional[dict] = None) -> Any:
         return self._request("POST", path, json_body=payload, params=params)
 
-    def resolve_location_id(self, location_name: str) -> int:
-        """Map a schedule location label to Open API location id."""
+    def resolve_location_id(
+        self, location_name: str, *, class_detail: Optional[dict] = None
+    ) -> int:
+        """Resolve cart ``locationId`` (org location, not room name).
+
+        Physical sites like \"El Segundo\" map to ``roomName`` on the class; JWT
+        cart APIs use the org location id (typically ``1`` for SCAQ).
+        """
+        if class_detail and class_detail.get("locationId") is not None:
+            return int(class_detail["locationId"])
+
         key = location_name.strip().lower()
         if key in self._location_ids:
             return self._location_ids[key]
-        data = self._fetch_open(f"{self.portal}/locations")
-        rows = data if isinstance(data, list) else (data or {}).get("data") or []
-        for row in rows:
-            if not isinstance(row, dict):
-                continue
-            name = str(row.get("name") or "").strip()
-            lid = row.get("id")
-            if name and lid is not None:
-                self._location_ids[name.lower()] = int(lid)
-        needle = key
+
+        try:
+            rows = self._get("locations")
+            if isinstance(rows, list):
+                for row in rows:
+                    if isinstance(row, dict) and row.get("id") is not None:
+                        name = str(row.get("name") or "").strip().lower()
+                        self._location_ids[name] = int(row["id"])
+        except Exception as exc:
+            logger.debug("JWT locations lookup failed: %s", exc)
+
+        if len(self._location_ids) == 1:
+            return next(iter(self._location_ids.values()))
+
         for name, lid in self._location_ids.items():
-            if needle == name or needle in name or name in needle:
+            if key == name or key in name or name in key:
                 return lid
-        raise ValueError(f"Could not resolve location id for {location_name!r}")
+
+        logger.warning(
+            "Could not map location %r to a JWT location id; using 1.",
+            location_name,
+        )
+        return 1
+
+    def select_organization(self, location_id: int) -> None:
+        """Prime org/location context (portal calls this before cart operations)."""
+        self._post(
+            "organizations",
+            {
+                "code": self.portal,
+                "bundleIdentifier": None,
+                "location": location_id,
+            },
+        )
 
     def _fetch_open(self, path: str, params: Optional[dict] = None) -> Any:
         slug_path = path.strip("/")
@@ -242,27 +271,66 @@ class IClassProAPIClient:
 
     def _build_cart_item_payload(
         self,
-        new_cart_data: dict,
-        class_id: int,
-        session_id: int,
+        class_detail: dict,
+        session: dict,
         student_id: int,
+        cart_item_id: str,
         *,
         start_date: Optional[str] = None,
     ) -> dict:
-        """Build a ``newCartItems[]`` element from ``new-cart-item`` API data."""
-        item = dict(new_cart_data.get("cartItem") or new_cart_data.get("newCartItem") or {})
-        if not item:
-            details = new_cart_data.get("cartItemDetails") or {}
-            if isinstance(details, dict) and details:
-                item = {"cartItemDetails": details}
-        item.setdefault("objectId", class_id)
-        item.setdefault("sessionId", session_id)
-        item.setdefault("selectedStudentIds", [student_id])
-        if start_date:
-            item.setdefault("startDate", start_date)
-        elif new_cart_data.get("startDate"):
-            item.setdefault("startDate", new_cart_data.get("startDate"))
-        return item
+        """Build ``newCartItems[]`` element matching the portal SPA shape."""
+        class_id = int(class_detail.get("id"))
+        session_id = int(session.get("id") or session.get("sessionId"))
+        available = class_detail.get("availableDays") or []
+        start = start_date or (available[0] if available else None)
+        end = session.get("endDate") or start
+        session_payload = dict(session)
+        if start and not session_payload.get("nextAvailableDate"):
+            session_payload["nextAvailableDate"] = start
+
+        return {
+            "cartItemId": cart_item_id,
+            "objectId": class_id,
+            "cartItemType": "class-enrollment",
+            "enrollmentType": "active",
+            "studentId": student_id,
+            "sessionId": session_id,
+            "sessions": [session_payload],
+            "startDate": start,
+            "endDate": end,
+            "blocks": [],
+            "addOns": [],
+            "recurring": False,
+            "objectName": (class_detail.get("name") or "").strip(),
+        }
+
+    @staticmethod
+    def _cart_errors(data: Any) -> list:
+        if not isinstance(data, dict):
+            return []
+        out: list = []
+        for entry in data.get("errors") or []:
+            if entry:
+                out.append(entry)
+        for entry in data.get("cartItems") or []:
+            if isinstance(entry, dict) and entry.get("errors"):
+                out.append(entry)
+        if data.get("success") is False and not out:
+            out.append({"message": "cart operation failed"})
+        return out
+
+    @staticmethod
+    def _format_cart_errors(errors: list) -> str:
+        parts = []
+        for entry in errors:
+            if isinstance(entry, dict):
+                if entry.get("errors"):
+                    parts.extend(str(x) for x in entry["errors"])
+                elif entry.get("message"):
+                    parts.append(str(entry["message"]))
+            else:
+                parts.append(str(entry))
+        return "; ".join(parts) or "Cart API rejected the item."
 
     def add_session_to_cart(
         self,
@@ -271,6 +339,7 @@ class IClassProAPIClient:
         student_id: int,
         location_id: int,
         *,
+        class_detail: Optional[dict] = None,
         start_date: Optional[str] = None,
     ) -> None:
         """Validate and add one session — mirrors portal Enroll → Add to Cart."""
@@ -281,21 +350,65 @@ class IClassProAPIClient:
             student_id,
             location_id,
         )
+        detail = class_detail or self.get_class_detail(class_id, student_id)
+        sessions = detail.get("sessions") or []
+        session = next(
+            (s for s in sessions if int(s.get("id") or s.get("sessionId") or 0) == int(session_id)),
+            sessions[0] if sessions else None,
+        )
+        if not session:
+            raise ValueError(f"No session {session_id} on class {class_id}")
+
+        self.select_organization(location_id)
         draft = self.fetch_new_cart_item(
             class_id, session_id, student_id, start_date=start_date
         )
+        cart_item_id = draft.get("cartItemId")
+        if not cart_item_id:
+            raise RuntimeError(f"new-cart-item returned no cartItemId: {draft}")
+
         cart_item = self._build_cart_item_payload(
-            draft, class_id, session_id, student_id, start_date=start_date
+            detail, session, student_id, str(cart_item_id), start_date=start_date
         )
-        new_cart_items = [cart_item]
-        body = {"newCartItems": new_cart_items, "locationId": location_id}
-        self._post("/validate-cart-item", body)
-        self._post("/add-cart-item", body)
+        body = {
+            "newCartItems": [cart_item],
+            "locationId": location_id,
+            "guestCheckoutKey": None,
+        }
+        validated = self._post("/validate-cart-item", body)
+        val_errors = self._cart_errors(validated)
+        if val_errors:
+            msg = self._format_cart_errors(val_errors)
+            if "already" in msg.lower() or "conflicting enrollment" in msg.lower():
+                raise EnrollmentSkipped(msg)
+            raise IClassProAPIError(msg)
+
+        added = self._post("/add-cart-item", body)
+        add_errors = self._cart_errors(added)
+        if add_errors or (isinstance(added, dict) and added.get("success") is False):
+            msg = self._format_cart_errors(add_errors)
+            if "already" in msg.lower() or "conflicting enrollment" in msg.lower():
+                raise EnrollmentSkipped(msg)
+            raise IClassProAPIError(msg or "add-cart-item failed.")
+
         logger.info("Cart item added (class=%s, session=%s).", class_id, session_id)
 
     def apply_promo_code(self, code: str) -> None:
         logger.info("Applying promo code: %s", code)
-        self._post("/add-promo-code", {"promoCode": code, "promoCodes": [code]})
+        last_error: Optional[Exception] = None
+        for variant in (code, code.lower(), code.upper()):
+            if not variant:
+                continue
+            try:
+                self._post(
+                    "/add-promo-code",
+                    {"promoCode": variant, "promoCodes": [variant]},
+                )
+                return
+            except Exception as exc:
+                last_error = exc
+        if last_error:
+            raise last_error
 
     def validate_cart(self, location_id: int) -> dict:
         data = self._get(f"/validate-cart/{location_id}")
@@ -396,17 +509,11 @@ def enroll_from_schedule(
         }
 
         try:
-            location_id = client.resolve_location_id(location)
             class_url = str(entry.get("url") or "").strip()
             class_id = _parse_class_id_from_url(class_url)
 
             day_idx = DAY_TO_QUERY_INDEX.get(day.lower())
-            open_row = None
-            if class_id is not None:
-                open_row = client.fetch_open_class_row(
-                    class_id, day_index=day_idx, location_filter=location
-                )
-            elif day_idx is not None:
+            if class_id is None and day_idx is not None:
                 open_row = _match_open_catalog_row(client, location, time_str, day_idx)
                 if open_row:
                     class_id = int(open_row["id"])
@@ -414,30 +521,26 @@ def enroll_from_schedule(
             if class_id is None:
                 raise ValueError(f"No class found for {label}")
 
-            session_id = None
-            start_date = None
-            if open_row:
-                session_id = _session_id_from_open_row(open_row)
-                start_date = open_row.get("startDate") or None
-                if not start_date:
-                    dates = open_row.get("availableDates") or []
-                    if dates:
-                        start_date = dates[0]
-
-            if session_id is None:
-                detail = client.get_class_detail(class_id, student_id)
-                sessions = detail.get("sessions") or []
-                if not sessions:
-                    raise ValueError(f"No sessions found for class {class_id}")
-                sess = sessions[0]
-                session_id = int(sess.get("id") or sess.get("sessionId"))
-                start_date = start_date or sess.get("startDate")
+            detail = client.get_class_detail(class_id, student_id)
+            location_id = client.resolve_location_id(location, class_detail=detail)
+            sessions = detail.get("sessions") or []
+            if not sessions:
+                raise ValueError(f"No sessions found for class {class_id}")
+            sess = sessions[0]
+            session_id = int(sess.get("id") or sess.get("sessionId"))
+            available = detail.get("availableDays") or []
+            start_date = (
+                (available[0] if available else None)
+                or sess.get("startDate")
+                or detail.get("transferDate")
+            )
 
             client.add_session_to_cart(
                 class_id,
                 session_id,
                 student_id,
                 location_id,
+                class_detail=detail,
                 start_date=start_date,
             )
             added_by_location[location_id] = added_by_location.get(location_id, 0) + 1
@@ -455,24 +558,32 @@ def enroll_from_schedule(
         summary.append(result)
 
     checkout_result: Optional[dict] = None
-    if added_by_location and complete_transaction:
+    if added_by_location:
         if promo_code:
             try:
                 client.apply_promo_code(promo_code)
+                logger.info("Promo code applied.")
             except Exception as exc:
                 logger.warning("Promo code failed (continuing): %s", exc)
 
-        # One checkout per location that received items (usually one).
-        checkout_results = []
-        for loc_id in added_by_location:
-            checkout_results.append(client.checkout(loc_id, complete_transaction=True))
-        checkout_result = (
-            checkout_results[0] if len(checkout_results) == 1 else checkout_results
-        )
-
-    elif added_by_location and not complete_transaction:
-        loc_id = next(iter(added_by_location))
-        checkout_result = client.checkout(loc_id, complete_transaction=False)
+        if complete_transaction:
+            checkout_results = []
+            for loc_id in added_by_location:
+                checkout_results.append(
+                    client.checkout(loc_id, complete_transaction=True)
+                )
+            checkout_result = (
+                checkout_results[0] if len(checkout_results) == 1 else checkout_results
+            )
+        else:
+            loc_id = next(iter(added_by_location))
+            cart_state = client.validate_cart(loc_id)
+            checkout_result = {
+                "dry_run": True,
+                "message": "Transaction not submitted (dry-run mode).",
+                "cart_total_due": cart_state.get("totalCartDueAmount"),
+                "cart_items": len(cart_state.get("cartItems") or []),
+            }
 
     return summary, checkout_result
 

--- a/scripts/capture_cart_api.py
+++ b/scripts/capture_cart_api.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""One-shot: log JWT cart API calls during Playwright add-to-cart (no checkout)."""
+
+import json
+import os
+import sys
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _ROOT)
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(_ROOT, ".env"), override=True)
+
+from playwright.sync_api import sync_playwright
+
+URL = (
+    "https://portal.iclasspro.com/scaq/class-details/15395"
+    "?selectedStudents=7268&filters=%7B%22students%22%3A%20%227268%22%2C%20%22days%22%3A%20%221%22%7D"
+)
+logged: list[dict] = []
+
+
+def main() -> int:
+    email = os.getenv("ICLASS_EMAIL", "")
+    password = os.getenv("ICLASS_PASSWORD", "")
+    if not email or not password:
+        print("Missing credentials in .env", file=sys.stderr)
+        return 1
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        state = os.path.join(_ROOT, "storage_state.json")
+        ctx = (
+            browser.new_context(storage_state=state)
+            if os.path.exists(state)
+            else browser.new_context()
+        )
+        page = ctx.new_page()
+
+        def on_request(req):
+            if "app.iclasspro.com/api/jwt" not in req.url:
+                return
+            if req.method not in ("POST", "PUT", "PATCH"):
+                return
+            entry = {"method": req.method, "url": req.url}
+            try:
+                entry["body"] = req.post_data_json
+            except Exception:
+                entry["body"] = req.post_data
+            logged.append(entry)
+
+        page.on("request", on_request)
+        page.goto(URL, wait_until="domcontentloaded", timeout=60000)
+        if "login" in page.url.lower():
+            page.goto(
+                "https://portal.iclasspro.com/scaq/login?showLogin=1",
+                wait_until="domcontentloaded",
+            )
+            page.fill("#email", email)
+            page.fill("#password", password)
+            page.locator("button:has-text('Log In')").first.click()
+            page.wait_for_timeout(3000)
+            page.goto(URL, wait_until="domcontentloaded", timeout=60000)
+
+        for text in ("Enroll Now", "Add to Cart"):
+            page.get_by_role("button", name=text).first.click(timeout=30000)
+            page.wait_for_timeout(2000)
+
+        ctx.close()
+        browser.close()
+
+    out = os.path.join(_ROOT, "debug-artifacts", "captured_cart_api.json")
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    with open(out, "w") as f:
+        json.dump(logged, f, indent=2)
+    print(f"Wrote {len(logged)} request(s) to {out}")
+    for entry in logged:
+        print("\n", entry["method"], entry["url"])
+        print(json.dumps(entry.get("body"), indent=2)[:3000])
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/capture_promo_api.py
+++ b/scripts/capture_promo_api.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Capture JWT promo API calls when applying a code on the portal cart."""
+
+import json
+import os
+import sys
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _ROOT)
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(_ROOT, ".env"), override=True)
+
+from playwright.sync_api import sync_playwright
+
+PORTAL = os.getenv("ICLASS_PORTAL", "scaq").strip().strip("/")
+PROMO = os.getenv("ICLASS_PROMO_CODE", "").strip()
+logged: list[dict] = []
+
+
+def main() -> int:
+    email = os.getenv("ICLASS_EMAIL", "")
+    password = os.getenv("ICLASS_PASSWORD", "")
+    if not email or not password:
+        print("Missing credentials in .env", file=sys.stderr)
+        return 1
+    if not PROMO:
+        print("Set ICLASS_PROMO_CODE in .env", file=sys.stderr)
+        return 1
+
+    cart_url = f"https://portal.iclasspro.com/{PORTAL}/cart"
+
+    with sync_playwright() as p:
+        browser = p.chromium.launch(headless=True)
+        state = os.path.join(_ROOT, "storage_state.json")
+        ctx = (
+            browser.new_context(storage_state=state)
+            if os.path.exists(state)
+            else browser.new_context()
+        )
+        page = ctx.new_page()
+
+        def on_request(req):
+            if "app.iclasspro.com/api/jwt" not in req.url:
+                return
+            entry = {"method": req.method, "url": req.url}
+            try:
+                entry["body"] = req.post_data_json
+            except Exception:
+                entry["body"] = req.post_data
+            logged.append(entry)
+
+        page.on("request", on_request)
+        page.goto(cart_url, wait_until="domcontentloaded", timeout=60000)
+        if "login" in page.url.lower():
+            page.goto(
+                f"https://portal.iclasspro.com/{PORTAL}/login?showLogin=1",
+                wait_until="domcontentloaded",
+            )
+            page.fill("#email", email)
+            page.fill("#password", password)
+            page.locator("button:has-text('Log In')").first.click()
+            page.wait_for_timeout(3000)
+            page.goto(cart_url, wait_until="domcontentloaded", timeout=60000)
+
+        page.wait_for_timeout(3000)
+        count = page.locator(".cart-item, [class*='cart']").count()
+        print(f"Cart page loaded (rough item locators: {count})")
+
+        promo_link = page.locator("a:has-text('Use Promo Code')")
+        if promo_link.count() == 0:
+            print("No 'Use Promo Code' link — cart may be empty", file=sys.stderr)
+        else:
+            promo_link.first.click()
+            page.wait_for_timeout(1000)
+            page.locator("[name='promoCode']").fill(PROMO)
+            page.locator("button:has-text('Apply')").click()
+            page.wait_for_timeout(4000)
+
+        ctx.close()
+        browser.close()
+
+    out = os.path.join(_ROOT, "debug-artifacts", "captured_promo_api.json")
+    os.makedirs(os.path.dirname(out), exist_ok=True)
+    with open(out, "w") as f:
+        json.dump(logged, f, indent=2)
+
+    promo_calls = [
+        e
+        for e in logged
+        if "promo" in e.get("url", "").lower()
+        or (
+            isinstance(e.get("body"), dict)
+            and any("promo" in str(k).lower() for k in e["body"])
+        )
+    ]
+    print(f"Wrote {len(logged)} JWT request(s) to {out}")
+    print(f"Promo-related: {len(promo_calls)}")
+    for entry in promo_calls:
+        url = entry.get("url", "").split("?")[0]
+        print("\n", entry["method"], url)
+        print(json.dumps(entry.get("body"), indent=2)[:4000])
+    return 0 if promo_calls else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/probe_jwt_login.py
+++ b/scripts/probe_jwt_login.py
@@ -1,0 +1,44 @@
+#!/usr/bin/env python3
+"""Test JWT login against iClassPro (reads credentials from .env)."""
+
+import os
+import sys
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _ROOT not in sys.path:
+    sys.path.insert(0, _ROOT)
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(_ROOT, ".env"), override=True)
+
+from iclasspro_jwt import IClassProAPIClient, _default_portal_slug  # noqa: E402
+
+
+def main() -> int:
+    email = os.getenv("ICLASS_EMAIL", "").strip()
+    password = os.getenv("ICLASS_PASSWORD", "").strip()
+    portal = os.getenv("ICLASS_PORTAL", "").strip() or _default_portal_slug()
+
+    if not email or not password:
+        print("Set ICLASS_EMAIL and ICLASS_PASSWORD in .env", file=sys.stderr)
+        return 1
+
+    client = IClassProAPIClient(email, password, portal)
+    try:
+        token = client.login()
+    except Exception as exc:
+        print(f"FAIL: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"OK: login succeeded for account={portal} (token length {len(token)})")
+    try:
+        methods = client.get_payment_methods()
+        print(f"Payment methods on file: {len(methods)}")
+    except Exception as exc:
+        print(f"WARN: could not list payment methods: {exc}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/probe_promo_api.py
+++ b/scripts/probe_promo_api.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+"""Try JWT promo endpoints after adding a class to cart (dry-run helper)."""
+
+import os
+import sys
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _ROOT)
+
+from dotenv import load_dotenv
+
+load_dotenv(os.path.join(_ROOT, ".env"), override=True)
+
+from iclasspro_jwt import IClassProAPIClient, _default_portal_slug, clear_cart_before_enrollment
+
+
+def main() -> int:
+    email = os.environ["ICLASS_EMAIL"]
+    password = os.environ["ICLASS_PASSWORD"]
+    promo = os.getenv("ICLASS_PROMO_CODE", "").strip()
+    student_id = int(os.getenv("ICLASS_STUDENT_ID", "0"))
+    if not promo:
+        print("ICLASS_PROMO_CODE not set", file=sys.stderr)
+        return 1
+
+    schedule_path = sys.argv[1] if len(sys.argv) > 1 else os.path.join(
+        _ROOT, "schedules/tmp/test_sunday_el_segundo.json"
+    )
+    import json
+
+    with open(schedule_path) as f:
+        schedule = json.load(f)
+
+    clear_cart_before_enrollment(email, password, schedule=schedule)
+
+    from iclasspro_jwt import enroll_from_schedule
+
+    portal = _default_portal_slug()
+    client = IClassProAPIClient(email, password, portal)
+    client.login()
+
+    summary, _ = enroll_from_schedule(
+        client,
+        schedule,
+        student_id,
+        promo_code=None,
+        complete_transaction=False,
+    )
+    print("Enroll summary:", summary)
+
+    loc_id = 1
+    before = client.validate_cart(loc_id)
+    print("Before promo totalCartDueAmount:", before.get("totalCartDueAmount"))
+
+    try:
+        client.apply_promo_code(promo, location_id=loc_id)
+    except Exception as exc:
+        print("apply_promo_code failed:", exc)
+        return 1
+    after = client.validate_cart(loc_id)
+    due = after.get("totalCartDueAmount")
+    print("totalCartDueAmount:", due, "promoCodes:", after.get("promoCodes"))
+    return 0 if due == 0 or due == 0.0 else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/templates/index.html
+++ b/templates/index.html
@@ -416,6 +416,16 @@
                         Promo Code (optional)
                         <input type="text" id="promo_code" value="{{ promo_code }}">
                     </label>
+                    <label>
+                        Enrollment driver
+                        <select id="enrollment_driver" style="width:100%; margin-top:0.25rem;">
+                            <option value="playwright" {% if enrollment_driver == 'playwright' %}selected{% endif %}>Playwright (browser — default)</option>
+                            <option value="api" {% if enrollment_driver == 'api' %}selected{% endif %}>HTTP API (JWT — fast)</option>
+                        </select>
+                    </label>
+                    <small style="color: var(--muted-color); font-size: 0.8rem;">
+                        HTTP API uses portal JWT endpoints; if login fails, switch back to Playwright.
+                    </small>
                     <label style="display:flex; align-items:center; gap:0.5rem; margin-top:0.4rem;">
                         <input type="checkbox" id="complete_transaction" {% if complete_transaction %}checked{% endif %} style="width:1.1rem; height:1.1rem; margin:0; cursor:pointer;">
                         <span style="font-size: 0.9rem;">Complete Transaction</span>
@@ -1075,7 +1085,8 @@
                     promo_code: document.getElementById('promo_code').value,
                     complete_transaction: document.getElementById('complete_transaction').checked,
                     send_email: document.getElementById('send_email').checked,
-                    deep_debug: document.getElementById('deep_debug').checked
+                    deep_debug: document.getElementById('deep_debug').checked,
+                    enrollment_driver: document.getElementById('enrollment_driver').value
                 })
             }).catch(err => console.error('Could not save config to .env:', err));
         }
@@ -1118,6 +1129,13 @@
                     saveConfigToEnv();
                 });
             });
+
+            const enrollmentDriver = document.getElementById('enrollment_driver');
+            if (enrollmentDriver) {
+                enrollmentDriver.addEventListener('change', function() {
+                    saveConfigToEnv();
+                });
+            }
         }
 
         // ===== Manual: run schedule =====
@@ -1133,6 +1151,7 @@
             const complete_transaction = document.getElementById("complete_transaction").checked;
             const send_email = document.getElementById("send_email").checked;
             const deep_debug = document.getElementById("deep_debug").checked;
+            const enrollment_driver = document.getElementById("enrollment_driver").value;
             const schedule = getScheduleData();
             const schedulePayload = schedule.map(({ Location, Day, Time }) => ({ Location, Day, Time }));
 
@@ -1162,6 +1181,7 @@
                     complete_transaction,
                     send_email,
                     deep_debug,
+                    enrollment_driver,
                     schedule: schedulePayload
                 }));
             };
@@ -1400,6 +1420,7 @@
             const complete_transaction = document.getElementById("complete_transaction").checked;
             const send_email = document.getElementById("send_email").checked;
             const deep_debug = document.getElementById("deep_debug").checked;
+            const enrollment_driver = document.getElementById("enrollment_driver").value;
 
             saveConfigToEnv();
 
@@ -1433,6 +1454,7 @@
                     complete_transaction,
                     send_email,
                     deep_debug,
+                    enrollment_driver,
                     selected_classes: selected
                 }));
             };

--- a/templates/index.html
+++ b/templates/index.html
@@ -992,6 +992,22 @@
         }
 
         // ===== Shared status / terminal / stop =====
+        /** Parse enrollment subprocess output; avoid matching "0 failed" in Summary lines. */
+        function parseEnrollmentRunOutcome(terminalText) {
+            const t = terminalText || '';
+            if (/Enrollment completed successfully/i.test(t)) return 'success';
+            if (/Enrollment finished with some failures/i.test(t)) return 'partial';
+            if (/Enrollment failed with exit code/i.test(t)) return 'error';
+            if (/ERROR - Failed to enroll/i.test(t)) return 'error';
+            if (/\bfailed to enroll\b/i.test(t)) return 'error';
+            const summary = t.match(/Summary:\s*(\d+)\s+added,\s*\d+\s+skipped,\s*(\d+)\s+failed/i);
+            if (summary) {
+                if (parseInt(summary[2], 10) > 0) return 'error';
+                if (parseInt(summary[1], 10) > 0) return 'success';
+            }
+            return null;
+        }
+
         function updateStatus(state, text) {
             statusIndicator.className = `status-${state}`;
             statusIndicator.innerText = text;
@@ -1190,11 +1206,13 @@
 
             activeWs.onclose = function() {
                 if (isStopped) { activeWs = null; activeKind = null; return; }
-                if (terminal.innerText.includes("successfully")) {
+                const outcome = parseEnrollmentRunOutcome(terminal.innerText);
+                if (outcome === 'success' || outcome === 'partial') {
                     const total = document.querySelectorAll(".schedule-row").length;
                     const done = document.querySelectorAll(".status-done").length;
-                    updateStatus("success", `Completed: ${done} of ${total} classes added`);
-                } else if (terminal.innerText.includes("failed") || terminal.innerText.includes("Error")) {
+                    const label = outcome === 'partial' ? 'Completed with issues' : `Completed: ${done} of ${total} classes added`;
+                    updateStatus("success", label);
+                } else if (outcome === 'error' || /Error:/.test(terminal.innerText)) {
                     updateStatus("error", "Failed");
                 } else {
                     updateStatus("idle", "Disconnected");
@@ -1464,10 +1482,13 @@
             activeWs.onclose = function(event) {
                 if (isStopped) { activeWs = null; activeKind = null; return; }
                 const content = terminal.innerText || '';
-                if (content.includes('failed') || content.includes('Error')) {
-                    updateStatus('error', 'Failed');
-                } else if (content.includes('successfully')) {
+                const outcome = parseEnrollmentRunOutcome(content);
+                if (outcome === 'success') {
                     updateStatus('success', 'Completed');
+                } else if (outcome === 'partial') {
+                    updateStatus('success', 'Completed with issues');
+                } else if (outcome === 'error' || /Error:/.test(content)) {
+                    updateStatus('error', 'Failed');
                 } else if (event && event.code !== 1000 && event.code !== 1001) {
                     updateStatus('error', 'Connection lost');
                 } else {

--- a/templates/index.html
+++ b/templates/index.html
@@ -419,12 +419,12 @@
                     <label>
                         Enrollment driver
                         <select id="enrollment_driver" style="width:100%; margin-top:0.25rem;">
-                            <option value="playwright" {% if enrollment_driver == 'playwright' %}selected{% endif %}>Playwright (browser — default)</option>
-                            <option value="api" {% if enrollment_driver == 'api' %}selected{% endif %}>HTTP API (JWT — fast)</option>
+                            <option value="api" {% if enrollment_driver == 'api' %}selected{% endif %}>HTTP API (JWT — default)</option>
+                            <option value="playwright" {% if enrollment_driver == 'playwright' %}selected{% endif %}>Playwright (browser — fallback)</option>
                         </select>
                     </label>
                     <small style="color: var(--muted-color); font-size: 0.8rem;">
-                        HTTP API uses portal JWT endpoints; if login fails, switch back to Playwright.
+                        HTTP API is the default. Use Playwright only if JWT login fails.
                     </small>
                     <label style="display:flex; align-items:center; gap:0.5rem; margin-top:0.4rem;">
                         <input type="checkbox" id="complete_transaction" {% if complete_transaction %}checked{% endif %} style="width:1.1rem; height:1.1rem; margin:0; cursor:pointer;">


### PR DESCRIPTION
## Summary

- Adds `iclasspro_jwt.py`, a JWT REST client for portal enrollment (`/api/jwt/v1`) aligned with the customer portal SPA: login, cart validate/add, promo, and checkout.
- Wires `--driver api|playwright` through CLI and dashboard; **HTTP API is now the default**; Playwright remains a fallback.
- Clears the cart automatically at the start of every enrollment run (API and Playwright).
- Fixes promo application (`promoCode` + empty `promoCodes: []`) and verifies discount on the cart before continuing.
- Dashboard fixes: correct success/failure detection for enroll-selected runs (no longer flags `Summary: … 0 failed` as failure); suppresses urllib3 LibreSSL warning on macOS.

## Test plan

- [ ] Restart dashboard from this branch (`./run_dashboard.sh`)
- [ ] Configuration: HTTP API driver, promo code set, **Complete Transaction unchecked** for dry-run
- [ ] Discover classes → enroll selected → confirm status shows **Completed** and `cart_total_due: 0` with promo applied
- [ ] Confirm cart is cleared at run start (log: count N → 0)
- [ ] Optional: `python3 iclasspro.py --driver api --schedule <file> --dry-run` from CLI
- [ ] If JWT login fails for an org, switch driver to Playwright and confirm enrollment still works


Made with [Cursor](https://cursor.com)